### PR TITLE
Fixed first person view stutter going up a fast elevator

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -724,7 +724,7 @@ void CL_ParseClientdata (void)
 	}
 
 	cl.onground = (bits & SU_ONGROUND) != 0;
-	cl.onelevator = (bits & SU_ONELEVATOR) != 0;
+	cl.nostepsmooth = (bits & SU_NOSTEPSMOOTH) != 0;
 	cl.inwater = (bits & SU_INWATER) != 0;
 
 	if (bits & SU_WEAPONFRAME)

--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -724,6 +724,7 @@ void CL_ParseClientdata (void)
 	}
 
 	cl.onground = (bits & SU_ONGROUND) != 0;
+	cl.onelevator = (bits & SU_ONELEVATOR) != 0;
 	cl.inwater = (bits & SU_INWATER) != 0;
 
 	if (bits & SU_WEAPONFRAME)

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -182,6 +182,7 @@ typedef struct
 
 	qboolean	paused;			// send over by server
 	qboolean	onground;
+	qboolean	onelevator;		//Ivory-- to fix stuttery view going up elevators
 	qboolean	inwater;
 
 	int			intermission;	// don't change view angle, full screen, etc

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -182,8 +182,9 @@ typedef struct
 
 	qboolean	paused;			// send over by server
 	qboolean	onground;
-	qboolean	onelevator;		//Ivory-- to fix stuttery view going up elevators
 	qboolean	inwater;
+
+	qboolean	nostepsmooth;	//Ivory-- to fix stuttery view going up elevators and slopes
 
 	int			intermission;	// don't change view angle, full screen, etc
 	int			completed_time;	// latched at intermission start

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -100,7 +100,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SU_EXTEND2		(1<<23) // another byte to follow
 #define SU_WEAPONFRAME2	(1<<24) // 1 byte, this is .weaponframe & 0xFF00 (second byte)
 #define SU_WEAPONALPHA	(1<<25) // 1 byte, this is alpha for weaponmodel, uses ENTALPHA_ENCODE, not sent if ENTALPHA_DEFAULT
-#define SU_ONELEVATOR	(1<<26) // Ivory-- player is standing on an elevator
+#define SU_NOSTEPSMOOTH	(1<<26) // Ivory-- to fix stuttery view smoothing going up elevators and slopes
 #define SU_UNUSED27		(1<<27)
 #define SU_UNUSED28		(1<<28)
 #define SU_UNUSED29		(1<<29)

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -100,7 +100,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define SU_EXTEND2		(1<<23) // another byte to follow
 #define SU_WEAPONFRAME2	(1<<24) // 1 byte, this is .weaponframe & 0xFF00 (second byte)
 #define SU_WEAPONALPHA	(1<<25) // 1 byte, this is alpha for weaponmodel, uses ENTALPHA_ENCODE, not sent if ENTALPHA_DEFAULT
-#define SU_UNUSED26		(1<<26)
+#define SU_ONELEVATOR	(1<<26) // Ivory-- player is standing on an elevator
 #define SU_UNUSED27		(1<<27)
 #define SU_UNUSED28		(1<<28)
 #define SU_UNUSED29		(1<<29)

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -160,7 +160,7 @@ typedef struct client_s
 #define	FL_PARTIALGROUND		1024	// not all corners are valid
 #define	FL_WATERJUMP			2048	// player jumping out of water
 #define	FL_JUMPRELEASED			4096	// for jump debouncing
-#define	FL_ONELEVATOR			8192	// to remove stuttery view going up elevators
+#define	FL_NOSTEPSMOOTH			8192	// to remove stuttery view going up elevators and slopes
 
 // entity effects
 

--- a/Quake/server.h
+++ b/Quake/server.h
@@ -160,6 +160,7 @@ typedef struct client_s
 #define	FL_PARTIALGROUND		1024	// not all corners are valid
 #define	FL_WATERJUMP			2048	// player jumping out of water
 #define	FL_JUMPRELEASED			4096	// for jump debouncing
+#define	FL_ONELEVATOR			8192	// to remove stuttery view going up elevators
 
 // entity effects
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -827,8 +827,13 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 
 	bits |= SU_ITEMS;
 
-	if ( (int)ent->v.flags & FL_ONGROUND)
+	if ((int)ent->v.flags & FL_ONGROUND)
 		bits |= SU_ONGROUND;
+	else
+		ent->v.flags = (int)ent->v.flags & ~FL_ONELEVATOR;
+
+	if ((int)ent->v.flags & FL_ONELEVATOR)
+		bits |= SU_ONELEVATOR;
 
 	if ( ent->v.waterlevel >= 2)
 		bits |= SU_INWATER;

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -829,14 +829,12 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 
 	if ((int)ent->v.flags & FL_ONGROUND)
 		bits |= SU_ONGROUND;
-	else
-		ent->v.flags = (int)ent->v.flags & ~FL_ONELEVATOR;
-
-	if ((int)ent->v.flags & FL_ONELEVATOR)
-		bits |= SU_ONELEVATOR;
 
 	if ( ent->v.waterlevel >= 2)
 		bits |= SU_INWATER;
+
+	if ((int)ent->v.flags & FL_NOSTEPSMOOTH)
+		bits |= SU_NOSTEPSMOOTH;
 
 	for (i=0 ; i<3 ; i++)
 	{

--- a/Quake/sv_phys.c
+++ b/Quake/sv_phys.c
@@ -227,7 +227,6 @@ int ClipVelocity (vec3_t in, vec3_t normal, vec3_t out, float overbounce)
 	return blocked;
 }
 
-
 /*
 ============
 SV_FlyMove
@@ -307,7 +306,12 @@ int SV_FlyMove (edict_t *ent, float time, trace_t *steptrace)
 			blocked |= 2;		// step
 			if (steptrace)
 				*steptrace = trace;	// save for player extrafriction
+			ent->v.flags = (int)ent->v.flags & ~FL_NOSTEPSMOOTH;
 		}
+		else if (trace.plane.normal[2] < 1.f)
+			ent->v.flags = (int)ent->v.flags | FL_NOSTEPSMOOTH;
+		else
+			ent->v.flags = (int)ent->v.flags & ~FL_NOSTEPSMOOTH;
 
 //
 // run the impact function
@@ -517,14 +521,8 @@ void SV_PushMove (edict_t *pusher, float movetime)
 	// remove the onground flag for non-players
 		if (check->v.movetype != MOVETYPE_WALK)
 			check->v.flags = (int)check->v.flags & ~FL_ONGROUND;
-		else if(elevator)
-		{
-		//the pusher will stop the next think 
-			if(pusher->v.nextthink - pusher->v.ltime <= 0)
-				check->v.flags = (int)check->v.flags & ~FL_ONELEVATOR;
-			else
-				check->v.flags = (int)check->v.flags | FL_ONELEVATOR; //set onelevator flag
-		}
+		else if (elevator)
+			check->v.flags = (int)check->v.flags | FL_NOSTEPSMOOTH; //no step smoothing going up an elevator
 
 		VectorCopy (check->v.origin, entorig);
 		VectorCopy (check->v.origin, moved_from[num_moved]);

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -336,7 +336,10 @@ void SV_AirMove (void)
 
 // hack to not let you back into teleporter
 	if (sv.time < sv_player->v.teleport_time && fmove < 0)
+	{
 		fmove = 0;
+		sv_player->v.flags = (int)sv_player->v.flags & ~FL_ONELEVATOR;
+	}
 
 	for (i=0 ; i<3 ; i++)
 		wishvel[i] = forward[i]*fmove + right[i]*smove;

--- a/Quake/sv_user.c
+++ b/Quake/sv_user.c
@@ -336,10 +336,7 @@ void SV_AirMove (void)
 
 // hack to not let you back into teleporter
 	if (sv.time < sv_player->v.teleport_time && fmove < 0)
-	{
 		fmove = 0;
-		sv_player->v.flags = (int)sv_player->v.flags & ~FL_ONELEVATOR;
-	}
 
 	for (i=0 ; i<3 ; i++)
 		wishvel[i] = forward[i]*fmove + right[i]*smove;

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -842,7 +842,7 @@ void V_CalcRefdef (void)
 //johnfitz
 
 // smooth out stair step ups
-// Ivory-- stronger smoothing but not when on an elevator to avoid stuttering viewpoint
+// Ivory-- no smoothing going up an elevator to avoid stuttering
 	if (!noclip_anglehack && cl.onground && !cl.onelevator && ent->origin[2] > oldz) //johnfitz -- added exception for noclip
 	//FIXME: noclip_anglehack is set on the server, so in a nonlocal game this won't work.
 	{
@@ -853,11 +853,11 @@ void V_CalcRefdef (void)
 			//FIXME	I_Error ("steptime < 0");
 			steptime = 0;
 
-		oldz += steptime * 100;
+		oldz += steptime * 80;
 		if (oldz > ent->origin[2])
 			oldz = ent->origin[2];
-		if (ent->origin[2] - oldz > 24)
-			oldz = ent->origin[2] - 24;
+		if (ent->origin[2] - oldz > 12)
+			oldz = ent->origin[2] - 12;
 
 		heightdif = oldz - ent->origin[2];
 		r_refdef.vieworg[2] += heightdif;

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -842,8 +842,8 @@ void V_CalcRefdef (void)
 //johnfitz
 
 // smooth out stair step ups
-// Ivory-- no smoothing going up an elevator to avoid stuttering
-	if (!noclip_anglehack && cl.onground && !cl.onelevator && ent->origin[2] > oldz) //johnfitz -- added exception for noclip
+// Ivory-- no smoothing going up elevators and slopes to avoid stuttering
+	if (!noclip_anglehack && cl.onground && !cl.nostepsmooth && ent->origin[2] > oldz) //johnfitz -- added exception for noclip
 	//FIXME: noclip_anglehack is set on the server, so in a nonlocal game this won't work.
 	{
 		float steptime, heightdif;

--- a/Quake/view.c
+++ b/Quake/view.c
@@ -842,23 +842,26 @@ void V_CalcRefdef (void)
 //johnfitz
 
 // smooth out stair step ups
-	if (!noclip_anglehack && cl.onground && ent->origin[2] - oldz > 0) //johnfitz -- added exception for noclip
+// Ivory-- stronger smoothing but not when on an elevator to avoid stuttering viewpoint
+	if (!noclip_anglehack && cl.onground && !cl.onelevator && ent->origin[2] > oldz) //johnfitz -- added exception for noclip
 	//FIXME: noclip_anglehack is set on the server, so in a nonlocal game this won't work.
 	{
-		float steptime;
+		float steptime, heightdif;
 
 		steptime = cl.time - cl.oldtime;
 		if (steptime < 0)
 			//FIXME	I_Error ("steptime < 0");
 			steptime = 0;
 
-		oldz += steptime * 80;
+		oldz += steptime * 100;
 		if (oldz > ent->origin[2])
 			oldz = ent->origin[2];
-		if (ent->origin[2] - oldz > 12)
-			oldz = ent->origin[2] - 12;
-		r_refdef.vieworg[2] += oldz - ent->origin[2];
-		view->origin[2] += oldz - ent->origin[2];
+		if (ent->origin[2] - oldz > 24)
+			oldz = ent->origin[2] - 24;
+
+		heightdif = oldz - ent->origin[2];
+		r_refdef.vieworg[2] += heightdif;
+		view->origin[2] += heightdif;
 	}
 	else
 		oldz = ent->origin[2];


### PR DESCRIPTION
As per title.
The train of though is: entity is detected to be on a rising elevator, flag FL_ONELEVATOR is set on v.flags, which is then transfered to the client in sv_main.c and cl_parse.c (like FL_ONGROUND).
If cl.onelevator is true the step ups view smoothing in V_CalcRefdef is not processed.

Here is a before/after video comparison
https://youtu.be/r3UmACLNWI8