### PR TITLE
Unbound mouse wheel not spamming warnings while being used in the console.

### DIFF
--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -957,12 +957,14 @@ void Key_Event (int key, qboolean down)
 // handle autorepeats and stray key up events
 	if (down)
 	{
+		qboolean consolewheel = (key == K_MWHEELUP || key == K_MWHEELDOWN) && key_dest == key_console;
+
 		if (keydown[key])
 		{
 			if (key_dest == key_game && !con_forcedup)
 				return; // ignore autorepeats in game mode
 		}
-		else if (key >= 200 && !keybindings[key])
+		else if (key >= 200 && !keybindings[key] && !consolewheel) //Ivory-- if mousewheel is being used in console and it is unbound do not spam warning messages
 			Con_Printf ("%s is unbound, hit F4 to set.\n", Key_KeynumToString(key));
 	}
 	else if (!keydown[key])

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -957,14 +957,13 @@ void Key_Event (int key, qboolean down)
 // handle autorepeats and stray key up events
 	if (down)
 	{
-		qboolean consolewheel = (key == K_MWHEELUP || key == K_MWHEELDOWN) && key_dest == key_console;
-
 		if (keydown[key])
 		{
 			if (key_dest == key_game && !con_forcedup)
 				return; // ignore autorepeats in game mode
 		}
-		else if (key >= 200 && !keybindings[key] && !consolewheel) //Ivory-- if mousewheel is being used in console and it is unbound do not spam warning messages
+		else if (key >= 200 && !keybindings[key]
+		&& !((key == K_MWHEELUP || key == K_MWHEELDOWN) && key_dest == key_console)) //Ivory-- if mousewheel is being used in console to scroll and it is unbound do not spam warning messages
 			Con_Printf ("%s is unbound, hit F4 to set.\n", Key_KeynumToString(key));
 	}
 	else if (!keydown[key])


### PR DESCRIPTION
This might merely be a personal issue.
I do not bind mouse wheel to any in game actions and, while of course I understand the usefulness of reminding players they are trying to use an unbound key, I think these warning should not appear for the mousewheel when the console is being used since the wheel has indeed an assigned function, which is scrolling up and down the feed.