### PR TITLE
automated build for MacOS 11 using github actions

### DIFF
--- a/.github/workflows/c-cpp-macos.yml
+++ b/.github/workflows/c-cpp-macos.yml
@@ -1,0 +1,26 @@
+name: C/C++ CI for MacOS 11
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: brew install libglu sdl2
+    - name: make
+      run: make -f Makefile.darwin DO_USERDIRS=1 USE_SDL2=1
+      working-directory: ./quake
+    - name: archive binary
+      uses: actions/upload-artifact@v2
+      with: 
+        name: built
+        path: quake/quakespasm
+        retention-days: 60


### PR DESCRIPTION
This way if something breaks the build on MacOS, you'll know immediately. All without owning a mac! Because microsoft/github kindly [provides build automation for free for public repos](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), even for apple builds.

See successful build log [here](https://github.com/QUINTIX/quakespasm/runs/4123793104?check_suite_focus=true)

`make` step is locally reproducible on my model A1708 MacBook Pro (circa 2016 with Intel Core i5 6360U/skylake).

ideally `makefile.darwin` (or a variant) would use extant codec libraries provided by homebrew or are already pre-installed on the given image (libogg and libvorbis are already there) instead of what's in ./MacOS/codecs, but that'll be another PR for another day.