### PR TITLE
Add linker option -lm to fix undefined reference to GLIBC error

### DIFF
--- a/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
+++ b/Linux/CodeBlocks/QuakeSpasm-SDL2.cbp
@@ -39,6 +39,7 @@
 			<Add option="-DUSE_CODEC_WAVE" />
 		</Compiler>
 		<Linker>
+			<Add option="-lm" />
 			<Add option="`sdl2-config --libs`" />
 			<Add option="-lGL" />
 			<Add option="-lvorbisfile" />


### PR DESCRIPTION
I couldn't get it to compile, I'd get undefined reference to GLIBC from various places (depending on compile order), adding -lm to the link options fixed it.