### PR TITLE
Increase Max Skins to 256

### DIFF
--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -339,7 +339,7 @@ typedef struct mtriangle_s {
 } mtriangle_t;
 
 
-#define	MAX_SKINS	32
+#define	MAX_SKINS	256
 typedef struct {
 	int			ident;
 	int			version;


### PR DESCRIPTION
Increase maximum skins from 32 to 256.

QME seems capable of creating models with more than 256 skins, but starts to have issues much more than that so 256 seems reasonable.  This allows for some very interesting effects coupled with misc_model (and other qc incarnations of such, such as mapobject_custom) and its user settable animation looping and rate.