### PR TITLE
Add Support for Lit Water

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -1311,7 +1311,14 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 		}
 		else if (out->texinfo->texture->name[0] == '*') // warp surface
 		{
-			out->flags |= (SURF_DRAWTURB | SURF_DRAWTILED);
+			out->flags |= SURF_DRAWTURB;
+			if (out->texinfo->flags & TEX_SPECIAL)
+				out->flags |= SURF_DRAWTILED;
+			else if (out->samples && !loadmodel->haslitwater)
+			{
+				Con_DPrintf ("Map has lit water\n");
+				loadmodel->haslitwater = true;
+			}
 
 		// detect special liquid types
 			if (!strncmp (out->texinfo->texture->name, "*lava", 5))
@@ -1322,8 +1329,13 @@ static void Mod_LoadFaces (lump_t *l, qboolean bsp2)
 				out->flags |= SURF_DRAWTELE;
 			else out->flags |= SURF_DRAWWATER;
 
-			Mod_PolyForUnlitSurface (out);
-			GL_SubdivideSurface (out);
+			// polys are only created for unlit water here.
+			// lit water is handled in BuildSurfaceDisplayList
+			if (out->flags & SURF_DRAWTILED)
+			{
+				Mod_PolyForUnlitSurface (out);
+				GL_SubdivideSurface (out);
+			}
 		}
 		else if (out->texinfo->texture->name[0] == '{') // ericw -- fence textures
 		{

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -484,7 +484,7 @@ typedef struct qmodel_s
 	qboolean	viswarn; // for Mod_DecompressVis()
 
 	int			bspversion;
-
+	qboolean	haslitwater;
 //
 // alias model
 //

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -64,6 +64,7 @@ cvar_t	r_fullbright = {"r_fullbright","0",CVAR_NONE};
 cvar_t	r_lightmap = {"r_lightmap","0",CVAR_NONE};
 cvar_t	r_shadows = {"r_shadows","0",CVAR_ARCHIVE};
 cvar_t	r_wateralpha = {"r_wateralpha","1",CVAR_ARCHIVE};
+cvar_t	r_litwater = {"r_litwater","1",CVAR_NONE};
 cvar_t	r_dynamic = {"r_dynamic","1",CVAR_ARCHIVE};
 cvar_t	r_novis = {"r_novis","0",CVAR_ARCHIVE};
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -176,6 +176,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_shadows);
 	Cvar_RegisterVariable (&r_wateralpha);
 	Cvar_SetCallback (&r_wateralpha, R_SetWateralpha_f);
+	Cvar_RegisterVariable (&r_litwater);
 	Cvar_RegisterVariable (&r_dynamic);
 	Cvar_RegisterVariable (&r_novis);
 	Cvar_RegisterVariable (&r_speeds);

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -139,6 +139,7 @@ extern	cvar_t	r_wateralpha;
 extern	cvar_t	r_lavaalpha;
 extern	cvar_t	r_telealpha;
 extern	cvar_t	r_slimealpha;
+extern	cvar_t	r_litwater;
 extern	cvar_t	r_dynamic;
 extern	cvar_t	r_novis;
 extern	cvar_t	r_scale;


### PR DESCRIPTION
Add support for lit water.  This is now my own implementation.

This supports maps compiled with `-splitturb` as an argument on qbsp.exe using ericw's latest compile tools.  Adds new cvar `r_litwater` which defaults to 1 for lit (same scheme as ironwail).

Test map compiled with mix of liquids, brush models, and a few colored lights.:
[test_liquids.zip](https://github.com/sezero/quakespasm/files/9239008/test_liquids.zip)

Showing r_wateralpha at 1.0 here, but was tested with varying values for the separate liquids.
![image](https://user-images.githubusercontent.com/7354604/182291217-af263ca7-0eae-49bb-8918-f2b3be44cf15.png)