### PR TITLE
Fix MacOS mouse grabbing issue

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -212,6 +212,15 @@ void IN_Activate (void)
 #endif
 
 #if defined(USE_SDL2)
+#ifdef __APPLE__
+	{
+		// Work around https://github.com/sezero/quakespasm/issues/48
+		int width, height;
+		SDL_GetWindowSize((SDL_Window*) VID_GetWindow(), &width, &height);
+		SDL_WarpMouseInWindow((SDL_Window*) VID_GetWindow(), width / 2, height / 2);
+	}
+#endif
+
 	if (SDL_SetRelativeMouseMode(SDL_TRUE) != 0)
 	{
 		Con_Printf("WARNING: SDL_SetRelativeMouseMode(SDL_TRUE) failed.\n");


### PR DESCRIPTION
Fixes https://github.com/sezero/quakespasm/issues/48 by centering the mouse on the window prior to grabbing it.