### PR TITLE
Fix being able to turn while game is paused or menu is open

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -657,6 +657,9 @@ void IN_JoyMove (usercmd_t *cmd)
 	
 	if (!joy_active_controller)
 		return;
+
+	if (cl.paused || key_dest != key_game)
+		return;
 	
 	moveRaw.x = joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_LEFTX];
 	moveRaw.y = joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_LEFTY];
@@ -707,6 +710,10 @@ void IN_MouseMove(usercmd_t *cmd)
 
 	total_dx = 0;
 	total_dy = 0;
+
+	// do pause check after resetting total_d* so mouse movements during pause don't accumulate
+	if (cl.paused || key_dest != key_game)
+		return;
 
 	if ( (in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1) ))
 		cmd->sidemove += m_side.value * dmx;


### PR DESCRIPTION
This fixes several related issues:
- If you're playing with a controller, you can still turn the player while the game is paused or a menu is open. It's pretty jank as you may be controlling the faded scene in the background behind a menu, and it might make someone think their inputs aren't being read by the menu or that the game isn't truly paused.
- If the game is paused (with the pause key specifically, so that the mouse is still captured), then mouse movements continue to accumulate while you're paused, potentially causing a very sudden disorienting jump when the game is eventually unpaused.
- If you're chatting, then you can still look around (with the mouse or controller), though you can't move or shoot. This can be confusing if you don't realize you're locked in a menu (as every other case you're locked in a menu stops you from looking around with the mouse).