### PR TITLE
Fix joystick movement thresholds and run behavior

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -49,7 +49,8 @@ static cvar_t in_debugkeys = {"in_debugkeys", "0", CVAR_NONE};
 #endif
 
 // SDL2 Game Controller cvars
-cvar_t	joy_deadzone = { "joy_deadzone", "0.175", CVAR_ARCHIVE };
+cvar_t	joy_deadzone_look = { "joy_deadzone_look", "0.175", CVAR_ARCHIVE };
+cvar_t	joy_deadzone_move = { "joy_deadzone_move", "0.175", CVAR_ARCHIVE };
 cvar_t	joy_deadzone_trigger = { "joy_deadzone_trigger", "0.2", CVAR_ARCHIVE };
 cvar_t	joy_sensitivity_yaw = { "joy_sensitivity_yaw", "300", CVAR_ARCHIVE };
 cvar_t	joy_sensitivity_pitch = { "joy_sensitivity_pitch", "150", CVAR_ARCHIVE };
@@ -367,7 +368,8 @@ void IN_Init (void)
 	Cvar_RegisterVariable(&in_debugkeys);
 	Cvar_RegisterVariable(&joy_sensitivity_yaw);
 	Cvar_RegisterVariable(&joy_sensitivity_pitch);
-	Cvar_RegisterVariable(&joy_deadzone);
+	Cvar_RegisterVariable(&joy_deadzone_look);
+	Cvar_RegisterVariable(&joy_deadzone_move);
 	Cvar_RegisterVariable(&joy_deadzone_trigger);
 	Cvar_RegisterVariable(&joy_invert);
 	Cvar_RegisterVariable(&joy_exponent);
@@ -670,8 +672,8 @@ void IN_JoyMove (usercmd_t *cmd)
 		lookRaw = temp;
 	}
 	
-	moveDeadzone = IN_ApplyDeadzone(moveRaw, joy_deadzone.value);
-	lookDeadzone = IN_ApplyDeadzone(lookRaw, joy_deadzone.value);
+	moveDeadzone = IN_ApplyDeadzone(moveRaw, joy_deadzone_move.value);
+	lookDeadzone = IN_ApplyDeadzone(lookRaw, joy_deadzone_look.value);
 
 	moveEased = IN_ApplyMoveEasing(moveDeadzone, joy_exponent_move.value);
 	lookEased = IN_ApplyEasing(lookDeadzone, joy_exponent.value);

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -54,11 +54,11 @@ cvar_t	joy_deadzone_move = { "joy_deadzone_move", "0.175", CVAR_ARCHIVE };
 cvar_t	joy_outer_threshold_look = { "joy_outer_threshold_look", "0.02", CVAR_ARCHIVE };
 cvar_t	joy_outer_threshold_move = { "joy_outer_threshold_move", "0.02", CVAR_ARCHIVE };
 cvar_t	joy_deadzone_trigger = { "joy_deadzone_trigger", "0.2", CVAR_ARCHIVE };
-cvar_t	joy_sensitivity_yaw = { "joy_sensitivity_yaw", "300", CVAR_ARCHIVE };
-cvar_t	joy_sensitivity_pitch = { "joy_sensitivity_pitch", "150", CVAR_ARCHIVE };
+cvar_t	joy_sensitivity_yaw = { "joy_sensitivity_yaw", "240", CVAR_ARCHIVE };
+cvar_t	joy_sensitivity_pitch = { "joy_sensitivity_pitch", "130", CVAR_ARCHIVE };
 cvar_t	joy_invert = { "joy_invert", "0", CVAR_ARCHIVE };
-cvar_t	joy_exponent = { "joy_exponent", "3", CVAR_ARCHIVE };
-cvar_t	joy_exponent_move = { "joy_exponent_move", "3", CVAR_ARCHIVE };
+cvar_t	joy_exponent = { "joy_exponent", "2", CVAR_ARCHIVE };
+cvar_t	joy_exponent_move = { "joy_exponent_move", "2", CVAR_ARCHIVE };
 cvar_t	joy_swapmovelook = { "joy_swapmovelook", "0", CVAR_ARCHIVE };
 cvar_t	joy_enable = { "joy_enable", "1", CVAR_ARCHIVE };
 

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -51,6 +51,8 @@ static cvar_t in_debugkeys = {"in_debugkeys", "0", CVAR_NONE};
 // SDL2 Game Controller cvars
 cvar_t	joy_deadzone_look = { "joy_deadzone_look", "0.175", CVAR_ARCHIVE };
 cvar_t	joy_deadzone_move = { "joy_deadzone_move", "0.175", CVAR_ARCHIVE };
+cvar_t	joy_outer_threshold_look = { "joy_outer_threshold_look", "0.02", CVAR_ARCHIVE };
+cvar_t	joy_outer_threshold_move = { "joy_outer_threshold_move", "0.02", CVAR_ARCHIVE };
 cvar_t	joy_deadzone_trigger = { "joy_deadzone_trigger", "0.2", CVAR_ARCHIVE };
 cvar_t	joy_sensitivity_yaw = { "joy_sensitivity_yaw", "300", CVAR_ARCHIVE };
 cvar_t	joy_sensitivity_pitch = { "joy_sensitivity_pitch", "150", CVAR_ARCHIVE };
@@ -370,6 +372,8 @@ void IN_Init (void)
 	Cvar_RegisterVariable(&joy_sensitivity_pitch);
 	Cvar_RegisterVariable(&joy_deadzone_look);
 	Cvar_RegisterVariable(&joy_deadzone_move);
+	Cvar_RegisterVariable(&joy_outer_threshold_look);
+	Cvar_RegisterVariable(&joy_outer_threshold_move);
 	Cvar_RegisterVariable(&joy_deadzone_trigger);
 	Cvar_RegisterVariable(&joy_invert);
 	Cvar_RegisterVariable(&joy_exponent);
@@ -490,22 +494,24 @@ static joyaxis_t IN_ApplyMoveEasing(joyaxis_t axis, float exponent)
 IN_ApplyDeadzone
 
 in: raw joystick axis values converted to floats in +-1
-out: applies a circular deadzone and clamps the magnitude at 1
+out: applies a circular inner deadzone and a circular outer threshold and clamps the magnitude at 1
      (my 360 controller is slightly non-circular and the stick travels further on the diagonals)
 
-deadzone is expected to satisfy 0 < deadzone < 1
+deadzone is expected to satisfy 0 < deadzone < 1 - outer_threshold
+outer_threshold is expected to satisfy 0 < outer_threshold < 1 - deadzone
 
 from https://github.com/jeremiah-sypult/Quakespasm-Rift
 and adapted from http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html
 ================
 */
-static joyaxis_t IN_ApplyDeadzone(joyaxis_t axis, float deadzone)
+static joyaxis_t IN_ApplyDeadzone(joyaxis_t axis, float deadzone, float outer_threshold)
 {
 	joyaxis_t result = {0};
 	vec_t magnitude = IN_AxisMagnitude(axis);
 	
 	if ( magnitude > deadzone ) {
-		const vec_t new_magnitude = q_min(1.0, (magnitude - deadzone) / (1.0 - deadzone));
+		// rescale the magnitude so deadzone becomes 0, and 1-outer_threshold becomes 1
+		const vec_t new_magnitude = q_min(1.0, (magnitude - deadzone) / (1.0 - deadzone - outer_threshold));
 		const vec_t scale = new_magnitude / magnitude;
 		result.x = axis.x * scale;
 		result.y = axis.y * scale;
@@ -672,8 +678,8 @@ void IN_JoyMove (usercmd_t *cmd)
 		lookRaw = temp;
 	}
 	
-	moveDeadzone = IN_ApplyDeadzone(moveRaw, joy_deadzone_move.value);
-	lookDeadzone = IN_ApplyDeadzone(lookRaw, joy_deadzone_look.value);
+	moveDeadzone = IN_ApplyDeadzone(moveRaw, joy_deadzone_move.value, joy_outer_threshold_move.value);
+	lookDeadzone = IN_ApplyDeadzone(lookRaw, joy_deadzone_look.value, joy_outer_threshold_look.value);
 
 	moveEased = IN_ApplyMoveEasing(moveDeadzone, joy_exponent_move.value);
 	lookEased = IN_ApplyEasing(lookDeadzone, joy_exponent.value);


### PR DESCRIPTION
I've been playing a lot of both Quakespasm(/vkQuake) and the Kex port with a controller. Compared to Kex, I've noticed that fine movement control seems harder, and the always-run setting and the run key barely impact your speed when the joystick is held all the way. I decided to investigate the joystick handling code, and I fixed a few smoking gun issues that were holding things back.

1. Fixed the issue where holding the movement joystick at a 45 degree angle would make you move at a different angle instead (41 degrees if you have always-run set to "Vanilla", otherwise 60 degrees!). (Yes, this is the same as what happens if you hold the forward and left/right keyboard keys, but it's a bit disorienting when using a joystick where you're supposed to be able to feel the angle and have finer control over it.) Now you move at the same angle as the joystick, just like with the Kex port and most games.
2. Fixed the issue where holding the movement joystick all the way while not running would make you move at speed 283 instead of 200. This made it very hard to notice the difference between running and walking with a controller. This fix seems to also be consistent with the Kex port.
3. Fixed the issue where when running you reach the maximum speed while holding the joystick at only 83% (when joy_exponent_move is at its default value of 3, and when joy_exponent_move is 2, 75%, and when joy_exponent_move is 1, 57%). The joystick maxing out so early meant you had a much smaller than necessary window where you could actually adjust your speed.

The above two issues were partly caused by the IN_ApplyMoveEasing function. The function had this comment:

>same as IN_ApplyEasing, but scales the output by sqrt(2). this gives diagonal stick inputs coordinates of (+/-1,+/-1).
>forward/back/left/right will return +/- 1.41; this shouldn't be a problem because you can pull back on the stick to go slower (and the final speed is clamped by sv_maxspeed).

There's two things wrong with this: 1) forward/back/left/right going to 1.41 means that the walking speed will be too high, and the running speed will be clipped creating a large outer deadzone. 2) There's no need to scale things up to make diagonals output (+/-1,+/-1) instead of (+/-0.707,+/-0.707), because the latter already has magnitude 1 and anything with a magnitude higher than that will get scaled down.

4. Added joy_outer_threshold_{look,move} CVARs which create an outer deadzone on the joysticks. Helps the player reach the max speed even if their joystick isn't able to reach its max, and it can be turned up if someone preferred the past behavior. Defaults to 0.02 (2%).
 
(I picked 2% because 1% and 2% are values I've seen recommended, I wanted to copy the value from a modern popular fast-paced FPS with polished controller support, and 2% is the default value in Apex Legends which happens to have an unusually detailed controller settings menu I was able to learn from.)

5. Split the joy_deadzone CVAR into two joy_deadzone_{look,move} CVARs. Mostly done just to be a little more parallel with the joy_outer_threshold_{look,move} CVARs, and because the Kex port lets you set the joysticks' deadzones separately.
6. Changed the default values for joy_exponent and joy_exponent_move from 3 to 2. This part of the PR is kind of just an opinion but I think it's a good one. It feels better to me, it's closer to what the Kex port does by default, and it seems like 2 is a much more commonly recommended value ([this specific post by nivix (not OP) was useful to me for learning about modern joystick controls](https://www.neogaf.com/threads/why-aiming-in-your-game-feels-like-shit-bad-aim-mechanics-explained.1614503/#post-264260281); I'm tempted to implement joystick acceleration/rampup as described there sometime to try to get closer to Kex parity). The old value 3 is maybe a little better for fine slow aiming, but it causes an awkward cliff in the middle of the joystick response curve, making it harder to do things like continuously turning the right amount to keep facing an enemy that you're strafing around.

(I felt the Kex port's joystick response curve was pretty good, so I studied its config, took videos to measure the time it takes to move a given distance or turn around at various joystick values, and charted the results against different Quakespasm joy_exponent settings: [moving](https://docs.google.com/spreadsheets/d/1XouJKVMfTi9onuX7lN_q_12FJ-5znxDhqs8-Hgo0GPE/edit?usp=sharing), [turning](https://docs.google.com/spreadsheets/d/1xRX5lI01GnDQGPf2Se8CmxFt8Ny7nOGw7pH7EcEVyrE/edit?usp=sharing). I still don't fully understand Kex's response curves, but it's clear to me that joy_exponent{,_move}=2 is much closer to what it does than joy_exponent{,_move}=3.)