### PR TITLE
Fix out-of-bound reads when handling type sizes

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -55,6 +55,8 @@ int		type_size[8] = {
 	1	// sizeof(void *) / 4		// ev_pointer
 };
 
+#define	NUM_TYPE_SIZES	(int)(sizeof(type_size) / sizeof(type_size[0]))
+
 static ddef_t	*ED_FieldAtOfs (int ofs);
 static qboolean	ED_ParseEpair (void *base, ddef_t *key, const char *s);
 
@@ -493,6 +495,9 @@ void ED_Print (edict_t *ed)
 	// if the value is still all 0, skip the field
 		type = d->type & ~DEF_SAVEGLOBAL;
 
+		if (type >= NUM_TYPE_SIZES)
+			continue;
+
 		for (j = 0; j < type_size[type]; j++)
 		{
 			if (v[j])
@@ -544,6 +549,10 @@ void ED_Write (FILE *f, edict_t *ed)
 
 	// if the value is still all 0, skip the field
 		type = d->type & ~DEF_SAVEGLOBAL;
+
+		if (type >= NUM_TYPE_SIZES)
+			continue;
+
 		for (j = 0; j < type_size[type]; j++)
 		{
 			if (v[j])


### PR DESCRIPTION
Loading progs.dat that uses FTE extensions types causes undefined behavior when saving games or printing edicts to console

Example of this issue: https://github.com/JosiahJack/Keep/issues/14