### PR TITLE
Continuous integration via GitHub Actions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,21 @@
+name: Linux CI
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ["clang", "gcc"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: sudo apt update && sudo apt install libmad0-dev libsdl2-dev libvorbis-dev
+
+    - name: Build ${{ matrix.compiler }}
+      run: make --jobs=3 --keep-going --directory=Quake CC=${{ matrix.compiler }} USE_SDL2=1

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,25 @@
+name: macOS CI
+
+on: [push, pull_request]
+
+jobs:
+  build-mac-os:
+    name: Build macOS
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [x64, M1]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build ${{ matrix.architecture }}
+      shell: bash
+      run: |
+        set -o pipefail
+        xcodebuild \
+          -project MacOSX/QuakeSpasm.xcodeproj \
+          -configuration Release \
+          -target QuakeSpasm-SDL2-${{ matrix.architecture }} \
+        | xcpretty

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,24 @@
+name: Windows CI
+
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    name: Build Windows
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, Win32]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build ${{ matrix.platform }}
+      run: |
+        $vsroot = (Get-VisualStudioInstance).InstallationPath
+        $devenv = join-path $vsroot "Common7\IDE\devenv.com"
+        $solution = "Windows/VisualStudio/quakespasm.sln"
+        & $devenv $solution /Upgrade
+        & $devenv $solution /Build "Release|${{ matrix.platform }}"
+        if (-not $?) { throw "Build failed" }


### PR DESCRIPTION
* Windows 32- and 64-bit builds using Visual Studio solution
* Linux builds using GCC and Clang
* macOS x86_64 and arm64 builds using Xcode project

Runs from my fork: [Windows](https://github.com/alexey-lysiuk/quakespasm/actions/runs/5560971479), [Linux](https://github.com/alexey-lysiuk/quakespasm/actions/runs/5560971480), [macOS](https://github.com/alexey-lysiuk/quakespasm/actions/runs/5560971481).

First launch of Visual Studio that takes up to 5 minutes is a known issue. It's a problem of GitHub hosted Windows images, e.g. https://github.com/actions/runner-images/issues/128 and https://github.com/actions/runner-images/issues/5301. Unfortunately, this thing wasn't fixed yet on their side, and there is no official way to upgrade projects/solution without Visual Studio.