### PR TITLE
Use `MSBuild` in Windows CI workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,10 +14,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: microsoft/setup-msbuild@v1
+
     - name: Build ${{ matrix.platform }}
       run: |
-        $vsroot = (Get-VisualStudioInstance).InstallationPath
-        $devenv = join-path $vsroot "Common7\IDE\devenv.com"
-        $solution = "Windows/VisualStudio/quakespasm.sln"
-        & $devenv $solution /Build "Release|${{ matrix.platform }}"
+        $options = @( `
+          '-property:Configuration=Release', `
+          '-property:Platform=${{ matrix.platform }}', `
+          '-maxcpucount', `
+          '-verbosity:minimal' `
+        )
+        & msbuild Windows\VisualStudio\quakespasm.sln $options
         if (-not $?) { throw "Build failed" }


### PR DESCRIPTION
Build takes approx. 2 minutes instead of 6+.