### PR TITLE
player corpses show correct colors bugfix

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -515,6 +515,7 @@ void CL_ParseUpdate (int bits)
 		i = MSG_ReadByte();
 	else
 		i = ent->baseline.colormap;
+	ent->vcolormap = i;
 	if (!i)
 		ent->colormap = vid.colormap;
 	else

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -715,10 +715,10 @@ void R_DrawAliasModel (entity_t *e)
 	}
 	tx = paliashdr->gltextures[skinnum][anim];
 	fb = paliashdr->fbtextures[skinnum][anim];
-	if (e->colormap != vid.colormap && !gl_nocolors.value)
+	if (e->vcolormap && !gl_nocolors.value)
 	{
-		if ((uintptr_t)e >= (uintptr_t)&cl_entities[1] && (uintptr_t)e <= (uintptr_t)&cl_entities[cl.maxclients]) /* && !strcmp (currententity->model->name, "progs/player.mdl") */
-			tx = playertextures[e - cl_entities - 1];
+		if (e->model == cl_entities[e->vcolormap].model)
+			tx = playertextures[e->vcolormap - 1];
 	}
 	if (!gl_fullbrights.value)
 		fb = NULL;

--- a/Quake/render.h
+++ b/Quake/render.h
@@ -78,6 +78,7 @@ typedef struct entity_s
 											//  that splits bmodel, or NULL if
 											//  not split
 
+	unsigned char			vcolormap;		//polo - used for corpse shirt + pants colors
 	byte					alpha;			//johnfitz -- alpha
 	byte					scale;
 	byte					lerpflags;		//johnfitz -- lerping


### PR DESCRIPTION
GLQuake introduced a bug with player corpses always showing the default ranger colors, so I've restored this feature that used to work in WinQuake (and probably DOSQuake).

This patch fixes the corpse colors specifically, but the way WinQuake works is more flexible which would allow any model to use the colors a certain player has selected, but that's a more significant change which requires creating and freeing new textures.