### PR TITLE
"Angled" sprites from FTEQW

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -2956,7 +2956,7 @@ static void *Mod_LoadSpriteFrame (void * pin, mspriteframe_t **ppframe, int fram
 Mod_LoadSpriteGroup
 =================
 */
-static void *Mod_LoadSpriteGroup (void * pin, mspriteframe_t **ppframe, int framenum)
+static void *Mod_LoadSpriteGroup (void * pin, mspriteframe_t **ppframe, int framenum, spriteframetype_t type)
 {
 	dspritegroup_t		*pingroup;
 	mspritegroup_t		*pspritegroup;
@@ -2968,6 +2968,8 @@ static void *Mod_LoadSpriteGroup (void * pin, mspriteframe_t **ppframe, int fram
 	pingroup = (dspritegroup_t *)pin;
 
 	numframes = LittleLong (pingroup->numframes);
+	if (type == SPR_ANGLED && numframes != 8)
+		Sys_Error ("Mod_LoadSpriteGroup: Bad # of frames: %d", numframes);
 
 	pspritegroup = (mspritegroup_t *) Hunk_AllocName (sizeof (mspritegroup_t) +
 				(numframes - 1) * sizeof (pspritegroup->frames[0]), loadname);
@@ -3071,7 +3073,7 @@ static void Mod_LoadSpriteModel (qmodel_t *mod, void *buffer)
 		else
 		{
 			pframetype = (dspriteframetype_t *)
-					Mod_LoadSpriteGroup (pframetype + 1, &psprite->frames[i].frameptr, i);
+					Mod_LoadSpriteGroup (pframetype + 1, &psprite->frames[i].frameptr, i, frametype);
 		}
 	}
 

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -49,6 +49,19 @@ mspriteframe_t *R_GetSpriteFrame (entity_t *currentent)
 	{
 		pspriteframe = psprite->frames[frame].frameptr;
 	}
+	else if (psprite->frames[frame].type == SPR_ANGLED)
+	{
+		// erysdren - angled sprites code backported from FTEQW
+		vec3_t axis[3];
+		AngleVectors(currententity->angles, axis[0], axis[1], axis[2]);
+		{
+			float f = DotProduct(vpn, axis[0]);
+			float r = DotProduct(vright, axis[0]);
+			int dir = (atan2(r, f)+1.125*M_PI)*(4/M_PI);
+			pspritegroup = (mspritegroup_t *)psprite->frames[frame].frameptr;
+			pspriteframe = pspritegroup->frames[dir&7];
+		}
+	}
 	else
 	{
 		pspritegroup = (mspritegroup_t *)psprite->frames[frame].frameptr;

--- a/Quake/spritegn.h
+++ b/Quake/spritegn.h
@@ -104,7 +104,7 @@ typedef struct {
 	float	interval;
 } dspriteinterval_t;
 
-typedef enum { SPR_SINGLE=0, SPR_GROUP } spriteframetype_t;
+typedef enum { SPR_SINGLE=0, SPR_GROUP, SPR_ANGLED } spriteframetype_t;
 
 typedef struct {
 	spriteframetype_t	type;


### PR DESCRIPTION
I found out that FTEQW supports "angled" sprites, i.e. ones that change frame based on player viewing angle. The code is rather simple.

I ported it to QuakeSpasm in a few minutes.

To author an angled sprite, one must construct a regular sprite with a traditional "Group Frame" (with 8 frames in the group), and mark the type integer as "2" rather than "1".

This can be done using my sprconv tool:

https://github.com/erysdren/sprconv