### PR TITLE
Fix potential crash after loading of saved game

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1251,6 +1251,10 @@ static void Host_Loadgame_f (void)
 		entnum++;
 	}
 
+	// Free edicts allocated during map loading but no longer used after restoring saved game state
+	for (i = entnum; i < sv.num_edicts; i++)
+		ED_Free(EDICT_NUM(i));
+
 	sv.num_edicts = entnum;
 	sv.time = time;
 


### PR DESCRIPTION
When number of edicts parsed from saved game is smaller than `sv.num_edicts`, "old" edicts are not freed nor unlinked while their memory can be reused by newly spawned entities.

This commit fixes #64.