### PR TITLE
Check for QuakeEx.kpf in gamedir if not found in basedir

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2639,6 +2639,10 @@ void LOC_LoadFile (const char *file)
 	{
 		q_snprintf(path, sizeof(path), "%s/QuakeEX.kpf", com_basedir);
 		rw = SDL_RWFromFile(path, "rb");
+		if (!rw) {
+			q_snprintf(path, sizeof(path), "%s/QuakeEX.kpf", com_gamedir);
+			rw = SDL_RWFromFile(path, "rb");
+		}
 		#if defined(DO_USERDIRS)
 		if (!rw) {
 			q_snprintf(path, sizeof(path), "%s/QuakeEX.kpf", host_parms->userdir);


### PR DESCRIPTION
Many users play with a mix of original `.pak` files and mod content.

Currently, `QuakeEx.kpf` is *only* a dependency for rerelease content. The file itself hasn't been updated in over a year, at this point. Likewise, most new mods in the last two years continue to not need or even use this file, so it is not necessary to load and replace strings for each and every other mod.

`QuakeEx.kpf` is still useful if one wishes to play `mg1`, for example. However, it seems reasonable that if users wish to keep their `basedir` clean of otherwise unused files, they should have the option.

This would allow users to load `QuakeEx.kpf` from the `gamedir` path if it is not found in the `basedir` first. This way, users with more advanced setups or users who only wish to incorporate `mg1` have the option of placing `QuakeEx.kpf` in there, keeping files clean, separate, and functional without breaking any current functionality.