### PR TITLE
Add new game message hint

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -391,7 +391,7 @@ void M_SinglePlayer_Key (int key)
 		{
 		case 0:
 			if (sv.active)
-				if (!SCR_ModalMessage("Are you sure you want to\nstart a new game?\n", 0.0f))
+				if (!SCR_ModalMessage("Are you sure you want to\nstart a new game? (y/n)\n", 0.0f))
 					break;
 			IN_Activate();
 			key_dest = key_game;


### PR DESCRIPTION
The new game message didn't give a hint as to which button should be pressed to confirm or cancel. This message has been present since the [original release by id software](https://github.com/id-Software/Quake/blob/bf4ac424ce754894ac8f1dae6a3981954bc9852d/WinQuake/menu.c#L417C5-L417C5), and I thought it helped to simply add "y/n" at the end of the message for anyone who isn't familiar with how the modal message works.