### PR TITLE
Increase viewangles roll limit to 180

### DIFF
--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -280,10 +280,10 @@ void CL_AdjustAngles (void)
 		cl.viewangles[PITCH] = cl_minpitch.value;
 	//johnfitz
 
-	if (cl.viewangles[ROLL] > 50)
-		cl.viewangles[ROLL] = 50;
-	if (cl.viewangles[ROLL] < -50)
-		cl.viewangles[ROLL] = -50;
+	if (cl.viewangles[ROLL] > 180)
+		cl.viewangles[ROLL] = 180;
+	if (cl.viewangles[ROLL] < -180)
+		cl.viewangles[ROLL] = -180;
 }
 
 /*

--- a/Quake/cl_input.c
+++ b/Quake/cl_input.c
@@ -234,6 +234,8 @@ cvar_t	cl_anglespeedkey = {"cl_anglespeedkey","1.5",CVAR_NONE};
 
 cvar_t	cl_alwaysrun = {"cl_alwaysrun","0",CVAR_ARCHIVE}; // QuakeSpasm -- new always run
 
+cvar_t	cl_maxroll = {"cl_maxroll", "180", CVAR_ARCHIVE}; //bmFbr -- variable Z roll clamping
+
 /*
 ================
 CL_AdjustAngles
@@ -280,10 +282,10 @@ void CL_AdjustAngles (void)
 		cl.viewangles[PITCH] = cl_minpitch.value;
 	//johnfitz
 
-	if (cl.viewangles[ROLL] > 180)
-		cl.viewangles[ROLL] = 180;
-	if (cl.viewangles[ROLL] < -180)
-		cl.viewangles[ROLL] = -180;
+	if (cl.viewangles[ROLL] > cl_maxroll.value)
+		cl.viewangles[ROLL] = cl_maxroll.value;
+	if (cl.viewangles[ROLL] < -cl_maxroll.value)
+		cl.viewangles[ROLL] = -cl_maxroll.value;
 }
 
 /*

--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -826,6 +826,8 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&cl_maxpitch); //johnfitz -- variable pitch clamping
 	Cvar_RegisterVariable (&cl_minpitch); //johnfitz -- variable pitch clamping
 
+	Cvar_RegisterVariable (&cl_maxroll); //bmFbr -- variable Z roll clamping
+
 	Cvar_RegisterVariable (&cl_startdemos);
 
 	Cmd_AddCommand ("entities", CL_PrintEntities_f);

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -266,6 +266,7 @@ extern	cvar_t	m_side;
 
 extern	cvar_t	cl_startdemos;
 
+extern	cvar_t	cl_maxroll;
 
 #define	MAX_TEMP_ENTITIES	256		//johnfitz -- was 64
 #define	MAX_STATIC_ENTITIES	4096	//ericw -- was 512	//johnfitz -- was 128


### PR DESCRIPTION
Quake historically puts a limit of 50 degrees for the player's v_angle Z component.

This limit seems arbitrary however, since the Z roll angle "sticks" and must be managed by the mod either way, and nothing breaks with it increased.