### PR TITLE
Fix buffer overflow in progs global string functions

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -418,6 +418,7 @@ const char *PR_GlobalString (int ofs)
 	static char	line[512];
 	const char	*s;
 	int		i;
+	static const int lastchari = Q_COUNTOF(line) - 2;
 	ddef_t		*def;
 	void		*val;
 
@@ -434,7 +435,11 @@ const char *PR_GlobalString (int ofs)
 	i = strlen(line);
 	for ( ; i < 20; i++)
 		strcat (line, " ");
-	strcat (line, " ");
+
+	if (i < lastchari)
+		strcat (line, " ");
+	else
+		line[lastchari] = ' ';
 
 	return line;
 }
@@ -443,6 +448,7 @@ const char *PR_GlobalStringNoContents (int ofs)
 {
 	static char	line[512];
 	int		i;
+	static const int lastchari = Q_COUNTOF(line) - 2;
 	ddef_t		*def;
 
 	def = ED_GlobalAtOfs(ofs);
@@ -454,7 +460,11 @@ const char *PR_GlobalStringNoContents (int ofs)
 	i = strlen(line);
 	for ( ; i < 20; i++)
 		strcat (line, " ");
-	strcat (line, " ");
+
+	if (i < lastchari)
+		strcat (line, " ");
+	else
+		line[lastchari] = ' ';
 
 	return line;
 }


### PR DESCRIPTION
Using v1.06 `progs.dat`, the following code causes buffer overflow as string value it references is long enough to fill entire `line` variable

```c
PR_PrintStatement(&pr_statements[5821]);
```