### PR TITLE
Add reference to readme file for Github

### DIFF
--- a/.github/README.txt
+++ b/.github/README.txt
@@ -1,0 +1,1 @@
+../Quakespasm.txt


### PR DESCRIPTION
I understand that Quakespasm's readme is contained in Quakespasm.txt. I included a relative symbolic link to make GitHub display the readme on the main page of this repository.