### PR TITLE
Applying FOV gun scaling for the triangle renderer as well

### DIFF
--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -981,6 +981,7 @@ void R_DrawAliasModel_ShowTris (entity_t *e)
 {
 	aliashdr_t	*paliashdr;
 	lerpdata_t	lerpdata;
+	float	fovscale = 1.0f;
 
 	if (R_CullModelForEntity(e))
 		return;
@@ -989,10 +990,13 @@ void R_DrawAliasModel_ShowTris (entity_t *e)
 	R_SetupAliasFrame (paliashdr, e->frame, &lerpdata);
 	R_SetupEntityTransform (e, &lerpdata);
 
+	if (e == &cl.viewent && scr_fov.value > 90.f && cl_gun_fovscale.value)
+		fovscale = tan(scr_fov.value * (0.5f * M_PI / 180.f));
+
 	glPushMatrix ();
 	R_RotateForEntity (lerpdata.origin,lerpdata.angles, e->scale);
-	glTranslatef (paliashdr->scale_origin[0], paliashdr->scale_origin[1], paliashdr->scale_origin[2]);
-	glScalef (paliashdr->scale[0], paliashdr->scale[1], paliashdr->scale[2]);
+	glTranslatef (paliashdr->scale_origin[0], paliashdr->scale_origin[1] * fovscale, paliashdr->scale_origin[2] * fovscale);
+	glScalef (paliashdr->scale[0], paliashdr->scale[1] * fovscale, paliashdr->scale[2] * fovscale);
 
 	shading = false;
 	glColor3f(1,1,1);


### PR DESCRIPTION
# Issue

The FOV gun scaling wasn't applied to the triangle renderer (with `r_showtris = 1`), resulting in geometry that differs from the output of the regular renderer:

![spasm0000](https://github.com/sezero/quakespasm/assets/54911023/14a84853-277b-478d-8418-5dc6e6a70541)

# Patch

I copied the scaling procedure to the triangle renderer which makes them match now:

![spasm0001](https://github.com/sezero/quakespasm/assets/54911023/95406aea-35bf-4075-9254-2e7518eab401)

The scaling procedure was copied from `R_DrawAliasModel()` into `R_DrawAliasModel_ShowTris`.

**Edit:**
I've set `fov 130`, `cl_gun_fovscale 1` and `r_showtris 1` when I made the screenshots.