### PR TITLE
Check if the requested game exists (Game change command)

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -2189,6 +2189,15 @@ static void COM_Game_f (void)
 			}
 		}
 
+		if (Sys_FileType(va("%s/%s", com_basedir, p)) != FS_ENT_DIRECTORY)
+		{
+			if (host_parms->userdir == host_parms->basedir || (Sys_FileType(va("%s/%s", host_parms->userdir, p)) != FS_ENT_DIRECTORY))
+			{
+				Con_Printf ("No such game directory \"%s\"\n", p);
+				return;
+			}
+		}
+
 		if (!q_strcasecmp(p, COM_SkipPath(com_gamedir))) //no change
 		{
 			if (com_searchpaths->path_id > 1) { //current game not id1


### PR DESCRIPTION
# Context

Closely related to issue #84, which I closed based on input from @Shpoike and @ericwa, who suggested that my patch (proposed in #84) would cause problems due to inconsistency in naming for assets from various Quake releases, which I ended up agreeing with (apologies for not clarifying that before closing the issue).

# Patch

I want to propose a different solution that does not use case sensitivity to compare the requested game name with the current one, but rather cancels the command if no matching game directory was found in the first place (briefly mentioned in #84).

I used `<filetype> != FS_ENT_DIRECTORY` to make sure that it cancels only if the path does not point to an existing directory (also works for symbolic links on Linux).

This patch aims to prevent situations where #84 would become a hindrance in Unix-based environments.

# Testing

```
game <name>
```

Should load the game if the directory was found by `Sys_FileType` or print ~`The game "<name>" couldn't be found.`~ `No such game directory "<name>"` if not.

**Edit: try this for both cases where user dirs are enabled and disabled (build with `DO_USERDIRS=1` to enable).**

# Notes
- I tested this in a Linux environment, and it also works for symbolic links to game directories.
- I've not tested this in a Windows environment.
- I've not tested this in a Mac OS environment (which I believe also uses the syscall `stat` implementation of `Sys_FileType`, similar to the Linux build).
- Spike also mentioned a different approach in #84 where the procedure is willing to accept partial matches.