### PR TITLE
Use SDL_ShowSimpleMessageBox() under SDL2

### DIFF
--- a/Quake/pl_linux.c
+++ b/Quake/pl_linux.c
@@ -91,5 +91,8 @@ char *PL_GetClipboardData (void)
 
 void PL_ErrorDialog (const char *errorMsg)
 {
+#if defined(USE_SDL2)
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Quake Error", errorMsg, NULL);
+#endif
 }
 


### PR DESCRIPTION
QuakeSpasm will show error message popups on Windows, but not Linux. There's no easy solution with SDL1, but under SDL2 you can use SDL_ShowSimpleMessageBox.