### PR TITLE
Adjust Con_SafePrintf message size limit

### DIFF
--- a/Quake/console.c
+++ b/Quake/console.c
@@ -625,7 +625,7 @@ Okay to call even when the screen can't be updated
 void Con_SafePrintf (const char *fmt, ...)
 {
 	va_list		argptr;
-	char		msg[1024];
+	char		msg[MAXPRINTMSG];
 	int		temp;
 
 	va_start (argptr, fmt);


### PR DESCRIPTION
Con_SafePrintf uses the same message size limit as the rest of console output functions.