### PR TITLE
First pass at improving *nix userdir handling

### DIFF
--- a/Linux/quakespasm.desktop
+++ b/Linux/quakespasm.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=QuakeSpasm
+Comment=A modernised fork of the Quake engine
+Icon=quakespasm
+TryExec=quakespasm
+Exec=quakespasm
+Categories=Game;ActionGame;Shooter;
+Keywords=first;person;shooter;fps;3d;quake;

--- a/Misc/quakespasm.svg
+++ b/Misc/quakespasm.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1151.5px" height="1735.2px" enable-background="new 0 0 1151.492 1735.227" version="1.1" viewBox="0 0 1151.5 1735.2" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><metadata><rdf:RDF><cc:Work rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/></cc:Work></rdf:RDF></metadata>
+<path d="m519.42 1109.2c-278.66-29.251-496.42-267.01-496.42-553.26 0-223.8 132.76-416.6 323.83-503.92l-0.016 17.282c-150.12 82.015-251.94 241.33-251.94 424.45 0 209.29 185.22 445.35 424.55 479.22v-197.81c-11.34-39.211-78.419-40.309-78.419-40.309v-12.267h272.58v12.267s-67.035 1.098-78.422 40.309c0 32.571 0.106 149.11 0.106 197.81 234.89-28.938 426.32-232.12 426.32-479.22 0-184.42-102.8-342.78-254.09-424.44v-17.283c190.61 87.5 323 280.64 323 504.11 0 301.9-216.69 525.66-495.24 553.08v0.166l-3e-3 175.7-60.881 303.66-54.947-303.66z"/>
+
+</svg>

--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -289,8 +289,20 @@ install:	quakespasm
 	cp quakespasm $(QS_APP_DIR)
 	cp quakespasm.pak $(QS_APP_DIR)
 else
+QS_BIN_DIR?=/usr/local/bin/
+QS_DATA_DIR?=/usr/local/share/
+QS_BASE_DIR?=$(QS_DATA_DIR)/games/quake/
+QS_APP_DIR?=$(QS_DATA_DIR)/applications/
+QS_ICON_DIR?=$(QS_DATA_DIR)/icons/hicolor/scalable/apps/
 install:	quakespasm
-	cp quakespasm /usr/local/games/quake
+	mkdir -p $(QS_BIN_DIR)
+	mkdir -p $(QS_BASE_DIR)
+	mkdir -p $(QS_APP_DIR)
+	mkdir -p $(QS_ICON_DIR)
+	cp quakespasm $(QS_BIN_DIR)
+	cp quakespasm.pak $(QS_BASE_DIR)
+	cp ../Linux/quakespasm.desktop $(QS_APP_DIR)
+	cp ../Misc/quakespasm.svg $(QS_ICON_DIR)
 endif
 
 sinclude $(OBJS:.o=.d)

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -280,7 +280,7 @@ static void Sys_GetUserdir (char *dst, size_t dstsize)
 	char *prefpath = SDL_GetPrefPath (NULL, SYS_USERDIR);
 	if (prefpath == NULL)
 		Sys_Error ("Couldn't determine userspace directory");
-	q_snprintf (dst, dstsize, "%s", basepath);
+	q_snprintf (dst, dstsize, "%s", prefpath);
 	SDL_free (prefpath);
 #else /* USE_SDL2 */
 	/* note - we're specifically not using XDG_CONFIG_HOME here so we can match

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -34,6 +34,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <sys/time.h>
 #include <fcntl.h>
 #ifdef DO_USERDIRS
+#include <sys/stat.h>
 #include <pwd.h>
 #endif
 
@@ -240,22 +241,26 @@ static int Sys_NumCPUs (void)
 }
 #endif
 
-static char	cwd[MAX_OSPATH];
+static char basedir[MAX_OSPATH];
+static char userdir[MAX_OSPATH];
 #ifdef DO_USERDIRS
-static char	userdir[MAX_OSPATH];
-#ifdef PLATFORM_OSX
-#define SYS_USERDIR	"Library/Application Support/QuakeSpasm"
-#elif defined(PLATFORM_HAIKU)
-#define SYS_USERDIR	"QuakeSpasm"
-#else
-#define SYS_USERDIR	".quakespasm"
-#endif
-
 #ifdef PLATFORM_HAIKU
+#define SYS_USERDIR "QuakeSpasm"
 #include <FindDirectory.h>
 #include <fs_info.h>
-
 static void Sys_GetUserdir (char *dst, size_t dstsize)
+{
+	dev_t volume = dev_for_path("/boot");
+	char buffer[B_PATH_NAME_LENGTH];
+	status_t result;
+
+	result = find_directory(B_USER_SETTINGS_DIRECTORY, volume, false, buffer, sizeof(buffer));
+	if (result != B_OK)
+		Sys_Error ("Couldn't determine userspace directory");
+
+	q_snprintf (dst, dstsize, "%s/%s", buffer, SYS_USERDIR);
+}
+static void Sys_GetBasedir (char *dst, size_t dstsize)
 {
 	dev_t volume = dev_for_path("/boot");
 	char buffer[B_PATH_NAME_LENGTH];
@@ -267,111 +272,67 @@ static void Sys_GetUserdir (char *dst, size_t dstsize)
 
 	q_snprintf (dst, dstsize, "%s/%s", buffer, SYS_USERDIR);
 }
-#else
+#else /* PLATFORM_HAIKU */
+#define SYS_USERDIR "quakespasm"
 static void Sys_GetUserdir (char *dst, size_t dstsize)
 {
-	size_t		n;
-	const char	*home_dir = NULL;
-	struct passwd	*pwent;
-
-	pwent = getpwuid( getuid() );
-	if (pwent == NULL)
-		perror("getpwuid");
-	else
-		home_dir = pwent->pw_dir;
-	if (home_dir == NULL)
-		home_dir = getenv("HOME");
-	if (home_dir == NULL)
+#ifdef USE_SDL2
+	char *prefpath = SDL_GetPrefPath (NULL, SYS_USERDIR);
+	if (prefpath == NULL)
 		Sys_Error ("Couldn't determine userspace directory");
-
-/* what would be a maximum path for a file in the user's directory...
- * $HOME/SYS_USERDIR/game_dir/dirname1/dirname2/dirname3/filename.ext
- * still fits in the MAX_OSPATH == 256 definition, but just in case :
- */
-	n = strlen(home_dir) + strlen(SYS_USERDIR) + 50;
-	if (n >= dstsize)
-		Sys_Error ("Insufficient array size for userspace directory");
-
-	q_snprintf (dst, dstsize, "%s/%s", home_dir, SYS_USERDIR);
-}
-#endif	/* PLATFORM_HAIKU */
-#endif	/* DO_USERDIRS */
-
-#ifdef PLATFORM_OSX
-static char *OSX_StripAppBundle (char *dir)
-{ /* based on the ioquake3 project at icculus.org. */
-	static char	osx_path[MAX_OSPATH];
-
-	q_strlcpy (osx_path, dir, sizeof(osx_path));
-	if (strcmp(basename(osx_path), "MacOS"))
-		return dir;
-	q_strlcpy (osx_path, dirname(osx_path), sizeof(osx_path));
-	if (strcmp(basename(osx_path), "Contents"))
-		return dir;
-	q_strlcpy (osx_path, dirname(osx_path), sizeof(osx_path));
-	if (!strstr(basename(osx_path), ".app"))
-		return dir;
-	q_strlcpy (osx_path, dirname(osx_path), sizeof(osx_path));
-	return osx_path;
-}
-
-static void Sys_GetBasedir (char *argv0, char *dst, size_t dstsize)
-{
-	char	*tmp;
-
-	if (realpath(argv0, dst) == NULL)
+	q_snprintf (dst, dstsize, "%s", basepath);
+	SDL_free (prefpath);
+#else /* USE_SDL2 */
+	/* note - we're specifically not using XDG_CONFIG_HOME here so we can match
+	 * the behaviour of SDL_GetPrefPath()
+	 */
+	const char *env = getenv("XDG_DATA_HOME");
+	if (env)
 	{
-		perror("realpath");
-		if (getcwd(dst, dstsize - 1) == NULL)
-	_fail:		Sys_Error ("Couldn't determine current directory");
+		q_snprintf (dst, dstsize, "%s/%s", env, SYS_USERDIR);
 	}
 	else
 	{
-		/* strip off the binary name */
-		if (! (tmp = strdup (dst))) goto _fail;
-		q_strlcpy (dst, dirname(tmp), dstsize);
-		free (tmp);
+		/* $XDG_DATA_HOME failed, try getpwuid */
+		struct passwd *pw = getpwuid(getuid());
+		/* give up */
+		if (!pw)
+			Sys_Error ("Couldn't determine userspace directory");
+		env = pw->pw_dir;
+		q_snprintf (dst, dstsize, "%s/.local/share/%s", env, SYS_USERDIR);
 	}
-
-	tmp = OSX_StripAppBundle(dst);
-	if (tmp != dst)
-		q_strlcpy (dst, tmp, dstsize);
+#endif /* USE_SDL2 */
 }
-#else
-static void Sys_GetBasedir (char *argv0, char *dst, size_t dstsize)
+static void Sys_GetBasedir (char *dst, size_t dstsize)
 {
-	char	*tmp;
-
-	#ifdef PLATFORM_HAIKU
-	if (realpath(argv0, dst) == NULL)
+	const char *env = getenv("XDG_DATA_HOME");
+	if (env)
 	{
-		perror("realpath");
-		if (getcwd(dst, dstsize - 1) == NULL)
-	_fail:		Sys_Error ("Couldn't determine current directory");
+		/* user-defined quake dir */
+		q_snprintf (dst, dstsize, "%s/games/quake", env);
 	}
 	else
 	{
-		/* strip off the binary name */
-		if (! (tmp = strdup (dst))) goto _fail;
-		q_strlcpy (dst, dirname(tmp), dstsize);
-		free (tmp);
+		/* fall back to system quake dir */
+		q_snprintf (dst, dstsize, "%s", "/usr/local/share/games/quake");
 	}
-	#else
+}
+#endif /* PLATFORM_HAIKU */
+#else /* DO_USERDIRS */
+static void Sys_GetBasedir (char *dst, size_t dstsize)
+{
+#ifdef USE_SDL2
+	char *basepath = SDL_GetBasePath ();
+	if (basepath == NULL)
+		Sys_Error ("Couldn't determine base directory");
+	q_snprintf (dst, dstsize, "%s", basepath);
+	SDL_free (basepath);
+#else /* USE_SDL2 */
 	if (getcwd(dst, dstsize - 1) == NULL)
-		Sys_Error ("Couldn't determine current directory");
-
-	tmp = dst;
-	while (*tmp != 0)
-		tmp++;
-	while (*tmp == 0 && tmp != dst)
-	{
-		--tmp;
-		if (tmp != dst && *tmp == '/')
-			*tmp = 0;
-	}
-	#endif
+		Sys_Error ("Couldn't determine base directory");
+#endif /* USE_SDL2 */
 }
-#endif
+#endif /* DO_USERDIRS */
 
 void Sys_Init (void)
 {
@@ -381,17 +342,23 @@ void Sys_Init (void)
 	if (!stdinIsATTY)
 		Sys_Printf("Terminal input not available.\n");
 
-	memset (cwd, 0, sizeof(cwd));
-	Sys_GetBasedir(host_parms->argv[0], cwd, sizeof(cwd));
-	host_parms->basedir = cwd;
-#ifndef DO_USERDIRS
-	host_parms->userdir = host_parms->basedir; /* code elsewhere relies on this ! */
-#else
+	memset (basedir, 0, sizeof(basedir));
 	memset (userdir, 0, sizeof(userdir));
-	Sys_GetUserdir(userdir, sizeof(userdir));
-	Sys_mkdir (userdir);
-	host_parms->userdir = userdir;
+
+	Sys_GetBasedir (basedir, sizeof(basedir));
+
+#ifdef DO_USERDIRS
+	Sys_GetUserdir (userdir, sizeof(userdir));
+#else
+	Sys_GetBasedir (userdir, sizeof(userdir));
 #endif
+
+	host_parms->basedir = basedir;
+	host_parms->userdir = userdir;
+	Sys_mkdir (host_parms->basedir);
+	Sys_mkdir (host_parms->userdir);
+
+	Sys_Printf("Basedir: %s\nUserdir: %s\n", host_parms->basedir, host_parms->userdir);
 	host_parms->numcpus = Sys_NumCPUs ();
 	Sys_Printf("Detected %d CPUs.\n", host_parms->numcpus);
 }


### PR DESCRIPTION
If it's built using SDL2, it will use the built-in functions `SDL_GetBasePath()` and `SDL_GetPrefPath()`. Otherwise it will prefer `~/.local/share/games/quake/` or `/usr/local/share/games/quake/`for game data and `~/.local/share/quakespasm/` for configuration files.

I've also reworked the desktop file and installation process in the makefile, as well as updated the Haiku code for userdirs.

`quakespasm.svg` attribution:

<a href="https://commons.wikimedia.org/wiki/File:Quake_logo.svg">Sasha Shor</a>, Public domain, via Wikimedia Commons