### PR TITLE
Fix field by index lookup

### DIFF
--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -196,7 +196,7 @@ static ddef_t *ED_FieldAtOfs (int ofs)
 	ddef_t		*def;
 	int			i;
 
-	for (i = 0; i < progs->numfielddefs; i++)
+	for (i = 1; i < progs->numfielddefs; i++)
 	{
 		def = &pr_fielddefs[i];
 		if (def->ofs == ofs)


### PR DESCRIPTION
Field by index lookup should start with one, `modelindex` field would never be picked otherwise

* Field at index zero is an invalid field with offset set to 0
* Field at index one is a valid field (`modelindex`) with offset set to 0 as well