### PR TITLE
Allow any supported music type to play

### DIFF
--- a/Quake/bgmusic.c
+++ b/Quake/bgmusic.c
@@ -69,8 +69,6 @@ static music_handler_t wanted_handlers[] =
 static music_handler_t *music_handlers = NULL;
 
 #define ANY_CODECTYPE	0xFFFFFFFF
-#define CDRIP_TYPES	(CODECTYPE_VORBIS | CODECTYPE_MP3 | CODECTYPE_FLAC | CODECTYPE_WAV | CODECTYPE_OPUS)
-#define CDRIPTYPE(x)	(((x) & CDRIP_TYPES) != 0)
 
 static snd_stream_t *bgmstream = NULL;
 
@@ -316,8 +314,6 @@ void BGM_PlayCDtrack (byte track, qboolean looping)
 	while (handler)
 	{
 		if (! handler->is_available)
-			goto _next;
-		if (! CDRIPTYPE(handler->type))
 			goto _next;
 		q_snprintf(tmp, sizeof(tmp), "%s/track%02d.%s",
 				MUSIC_DIRNAME, (int)track, handler->ext);

--- a/Quake/bgmusic.c
+++ b/Quake/bgmusic.c
@@ -69,6 +69,8 @@ static music_handler_t wanted_handlers[] =
 static music_handler_t *music_handlers = NULL;
 
 #define ANY_CODECTYPE	0xFFFFFFFF
+#define CDRIP_TYPES	(CODECTYPE_VORBIS | CODECTYPE_MP3 | CODECTYPE_FLAC | CODECTYPE_WAV | CODECTYPE_OPUS)
+#define CDRIPTYPE(x)	(((x) & CDRIP_TYPES) != 0)
 
 static snd_stream_t *bgmstream = NULL;
 
@@ -315,6 +317,8 @@ void BGM_PlayCDtrack (byte track, qboolean looping)
 	{
 		if (! handler->is_available)
 			goto _next;
+//		if (! CDRIPTYPE(handler->type))
+//			goto _next;
 		q_snprintf(tmp, sizeof(tmp), "%s/track%02d.%s",
 				MUSIC_DIRNAME, (int)track, handler->ext);
 		if (! COM_FileExists(tmp, &path_id))


### PR DESCRIPTION
Removes the restriction on CDRIP_TYPES for music. This unnecessary restriction makes the tracker formats supported by the engine (umx, mod, it, etc.) useless as they cannot be used for map music.

Removed the defines as well, as they were not used anywhere else.