### PR TITLE
Valve BSP, WAD, and external texture support

### DIFF
--- a/Quake/bspfile.h
+++ b/Quake/bspfile.h
@@ -59,6 +59,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define BSPVERSION	29
 
+#ifdef BSP29_VALVE
+#define BSPVERSION_VALVE 30
+#endif
+
 /* RMQ support (2PSB). 32bits instead of shorts for all but bbox sizes (which
  * still use shorts) */
 #define BSP2VERSION_2PSB (('B' << 24) | ('S' << 16) | ('P' << 8) | '2')

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -294,6 +294,14 @@ char *q_strupr (char *str)
 	return str;
 }
 
+char *q_strdup (const char *str)
+{
+	size_t len = strlen (str) + 1;
+	char  *newstr = (char *)malloc (len);
+	memcpy (newstr, str, len);
+	return newstr;
+}
+
 /* platform dependant (v)snprintf function names: */
 #if defined(_WIN32)
 #define	snprintf_func		_snprintf
@@ -1138,7 +1146,7 @@ void COM_FileBase (const char *in, char *out, size_t outsize)
 	dot = NULL;
 	while (*s)
 	{
-		if (*s == '/')
+		if (*s == '/' || *s == '\\')
 			slash = s + 1;
 		if (*s == '.')
 			dot = s;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -231,6 +231,9 @@ extern char *q_strcasestr(const char *haystack, const char *needle);
 extern char *q_strlwr (char *str);
 extern char *q_strupr (char *str);
 
+// strdup that calls malloc
+extern char *q_strdup (const char *str);
+
 /* snprintf, vsnprintf : always use our versions. */
 extern int q_snprintf (char *str, size_t size, const char *format, ...) FUNC_PRINTF(3,4);
 extern int q_vsnprintf(char *str, size_t size, const char *format, va_list args) FUNC_PRINTF(3,0);

--- a/Quake/gl_texmgr.h
+++ b/Quake/gl_texmgr.h
@@ -39,7 +39,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define TEXPREF_CONCHARS		0x0400	// use conchars palette
 #define TEXPREF_WARPIMAGE		0x0800	// resize this texture when warpimagesize changes
 
-enum srcformat {SRC_INDEXED, SRC_LIGHTMAP, SRC_RGBA};
+enum srcformat {SRC_INDEXED, SRC_LIGHTMAP, SRC_RGBA, SRC_INDEXED_PALETTE};
 
 typedef uintptr_t src_offset_t;
 

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -52,6 +52,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	GAMENAME	"id1"		// directory to look in by default
 
+#define BSP29_VALVE			// enable Half-Life map support
+
 #include "q_stdinc.h"
 
 // !!! if this is changed, it must be changed in d_ifacea.h too !!!

--- a/Quake/wad.h
+++ b/Quake/wad.h
@@ -38,7 +38,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	TYP_QTEX		65
 #define	TYP_QPIC		66
 #define	TYP_SOUND		67
+#define	TYP_MIPTEX_PALETTE	67
 #define	TYP_MIPTEX		68
+
+#define WADID		('W' | ('A' << 8) | ('D' << 16) | ('2' << 24))
+#define WADID_VALVE	('W' | ('A' << 8) | ('D' << 16) | ('3' << 24))
 
 #define	WADFILENAME "gfx.wad" //johnfitz -- filename is now hard-coded for honesty
 
@@ -66,15 +70,28 @@ typedef struct
 	char		name[16];				// must be null terminated
 } lumpinfo_t;
 
+typedef struct wad_s
+{
+	char		name[MAX_QPATH];
+	int			id;
+	fshandle_t	fh;
+	int			numlumps;
+	lumpinfo_t	*lumps;
+	struct wad_s	*next;
+} wad_t;
+
 extern	int			wad_numlumps;
 extern	lumpinfo_t	*wad_lumps;
 extern	byte		*wad_base;
 
 void	W_LoadWadFile (void); //johnfitz -- filename is now hard-coded for honesty
 void	W_CleanupName (const char *in, char *out);
-lumpinfo_t	*W_GetLumpinfo (const char *name);
 void	*W_GetLumpName (const char *name);
 void	*W_GetLumpNum (int num);
+
+wad_t	*W_LoadWadList (const char *names);
+void	W_FreeWadList (wad_t *wads);
+lumpinfo_t *W_GetLumpinfoList (wad_t *wads, const char *name, wad_t **out_wad);
 
 void SwapPic (qpic_t *pic);
 


### PR DESCRIPTION
![Test map](https://github.com/user-attachments/assets/f4943277-21f3-4fa1-aba5-e6c4e54f6f4c)

Valve format support and external WAD texture support!

I originally implemented these changes for vkQuake. @vsonnier suggested porting them here to benefit the broader modding community.

Quick overview:
- Textures are loaded from WADs if they aren't embedded within the map itself
- WAD3 full color textures
- BSP30 24-bit RGB lighting

See Novum/vkQuake#753 for more details. This PR contains all of the changes & fixes discussed there.

[Test maps](https://github.com/user-attachments/files/17967555/bsp30.zip)