### PR TITLE
Add support for modern macOS (Intel only)

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -65,6 +65,10 @@ CFLAGS += -O2
 #CFLAGS += -fno-asynchronous-unwind-tables
 CFLAGS += $(call check_gcc,-fweb,)
 CFLAGS += $(call check_gcc,-frename-registers,)
+ifeq ($(HOST_OS),darwin)
+CFLAGS += -arch x86_64
+LDFLAGS += -arch x86_64
+endif
 cmd_strip=$(STRIP) $(1)
 define do_strip
 	$(call cmd_strip,$(1));
@@ -164,6 +168,8 @@ endif
 
 ifeq ($(HOST_OS),haiku)
 COMMON_LIBS= -lGL
+else ifeq ($(HOST_OS),darwin)
+COMMON_LIBS= -framework OpenGL -framework IOKit -lm
 else
 COMMON_LIBS= -lGL -lm
 endif


### PR DESCRIPTION
Add support for macOS OpenGL and include IOKit. As of now I only added support for x86_64, because I don't have access to an Apple silicon machine to test and for some reason it won't compile into a universal binary. I will let someone else with an M-series Mac go figure it out but for now it compiles for Intel Macs.