### PR TITLE
Fix crash on launch reading out of bounds when loading some WAV files

### DIFF
--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -316,12 +316,20 @@ wavinfo_t GetWavinfo (const char *name, byte *wav, int wavlength)
 		FindNextChunk ("LIST");
 		if (data_p)
 		{
-			if (!strncmp((char *)data_p + 28, "mark", 4))
-			{	// this is not a proper parse, but it works with cooledit...
-				data_p += 24;
-				i = GetLittleLong();	// samples in loop
-				info.samples = info.loopstart + i;
-		//		Con_Printf("looped length: %i\n", i);
+			if (iff_chunk_len >= 32)
+			{
+				if (!strncmp((char *)data_p + 28, "mark", 4))
+				{
+					// this is not a proper parse, but it works with cooledit...
+					data_p += 24;
+					i = GetLittleLong();	// samples in loop
+					info.samples = info.loopstart + i;
+//					Con_Printf("looped length: %i\n", i);
+				}
+			}
+			else
+			{
+				Con_Warning("%s contains bad LIST chunk\n", name);
 			}
 		}
 	}


### PR DESCRIPTION
Crash appears to be caused by reading out of bounds memory when checking for the presence of "mark" inside the LIST chunk of certain WAV files. Possibly caused by badly authored WAV files, though I'm not sure exactly what the expected format & behaviour is here.

Crash occurred when trying to run librequake v0.09-beta FULL version on an M2 Mac, but it does not look like a Mac specific issue imo.