### PR TITLE
Search extension from the end of the map name instead of from the start.

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -858,9 +858,10 @@ static void Host_Map_f (void)
 	svs.serverflags = 0;			// haven't completed an episode yet
 	q_strlcpy (name, Cmd_Argv(1), sizeof(name));
 	// remove (any) trailing ".bsp" from mapname -- S.A.
-	p = strstr(name, ".bsp");
-	if (p && p[4] == '\0')
-		*p = '\0';
+	p = Q_strrchr(name, '.');
+	if (p != NULL)
+		if (Q_strcmp(p, ".bsp") == 0)
+			*p = '\0';
 	SV_SpawnServer (name);
 	if (!sv.active)
 		return;


### PR DESCRIPTION
Currently, the **map command** scans the name for a `.bsp` extension using `strstr()`. This works fine for any map that follows the naming style `name.bsp`, but would break with `pre.bspname.bsp` because it searches for the first occurence of `.bsp` from the start.

In the patch, I first search for the `.` character using `Q_strrchr()` which searches in reverse from the end of the string. If found, it compares using `Q_strcmp()` and terminates the string there if the extension was found.

I tested this by invoking the following commands:

```
map start
disconnect
map start.bsp
disconnect
map death
disconnect
map death.bsp
disconnect
map a.bspdeath
disconnect
map a.bspdeath.bsp
```

My `id1/maps` directory in fact has the files for testing purposes:

```
death.bsp
a.bspdeath.bsp
```

***death.bsp &rarr; [Death's Taste](https://www.quaddicted.com/db/v2/maps/e1c2d95b4cc4a5d71cc387b1062fbe5bdbf529b98fd6aa0c082f3ba23771f020)***