### PR TITLE
Fix svc_clientdata weapon byte potentially not being written

### DIFF
--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -836,6 +836,7 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 	edict_t	*other;
 	int		items;
 	eval_t	*val;
+	int		weapon;
 
 //
 // send a damage message
@@ -973,14 +974,16 @@ void SV_WriteClientdataToMessage (edict_t *ent, sizebuf_t *msg)
 	}
 	else
 	{
+		weapon = 0;
 		for(i=0;i<32;i++)
 		{
 			if ( ((int)ent->v.weapon) & (1<<i) )
 			{
-				MSG_WriteByte (msg, i);
+				weapon = i;
 				break;
 			}
 		}
+		MSG_WriteByte (msg, weapon);
 	}
 
 	//johnfitz -- PROTOCOL_FITZQUAKE


### PR DESCRIPTION
I was getting bad messages in my mod's mission pack branches. Turns out this was the cause. It happens as a result of setting the weapon to zero. This is a vanilla bug present in other forks, as well.