### PR TITLE
Update metainfo

### DIFF
--- a/Linux/net.sourceforge.quakespasm.Quakespasm.metainfo.xml
+++ b/Linux/net.sourceforge.quakespasm.Quakespasm.metainfo.xml
@@ -7,6 +7,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
   <url type="homepage">https://quakespasm.sourceforge.net/</url>
+  <url type="vcs-browser">https://sourceforge.net/projects/quakespasm/</url>
   <launchable type="desktop-id">net.sourceforge.quakespasm.Quakespasm.desktop</launchable>
   <description>
     <p>Quakespasm is a *Nix friendly Quake Engine based on the SDL port of the popular FitzQuake.


### PR DESCRIPTION
Rename from `.appdata.xml` to `.metainfo.xml` as per current AppStream standard and add `vcs-browser` URL as Flathub's linter now warns about this missing.